### PR TITLE
Choose relevant outboxes & remove Outbox active=True requirement

### DIFF
--- a/django_mail_admin/admin.py
+++ b/django_mail_admin/admin.py
@@ -87,21 +87,21 @@ def get_new_mail(mailbox_admin, request, queryset):
 get_new_mail.short_description = _("Get new mail")
 
 
-def switch_active(mailbox_admin, request, queryset):
-    for mailbox in queryset.all():
-        mailbox.active = not mailbox.active
-        mailbox.save()
-
-
-switch_active.short_description = _("Switch active status")
+# def switch_active(mailbox_admin, request, queryset):
+#     for mailbox in queryset.all():
+#         mailbox.active = not mailbox.active
+#         mailbox.save()
+#
+#
+# switch_active.short_description = _("Switch active status")
 
 
 def send_queued_mail(outbox_admin, request, queryset):
     outbox: Outbox = None
     for outbox in queryset.all():
-        if not outbox.active:
-            messages.error("Outbox not active!")
-            return
+        # if not outbox.active:
+        #     messages.error("Outbox not active!")
+        #     return
         default_processes = 1
         default_log_level = 1  # 0 - do nothing, 1 - only log errors
         default_lockfile = tempfile.gettempdir() + "/django_mail_admin"
@@ -147,7 +147,7 @@ class MailboxAdmin(get_parent()):
     readonly_fields = [
         "last_polling",
     ]
-    actions = [get_new_mail, switch_active]
+    actions = [get_new_mail]#, switch_active]
 
 
 class IncomingAttachmentInline(admin.TabularInline):
@@ -446,15 +446,19 @@ class OutgoingEmailAdmin(admin.ModelAdmin):
 
     to_display.short_description = _("To")
 
-    def get_form(self, request, obj=None, **kwargs):
-        # Try to get active Outbox and prepopulate from_email field
-        form = super(OutgoingEmailAdmin, self).get_form(request, obj, **kwargs)
-        configurations = Outbox.objects.filter(active=True)
-        if not (len(configurations) > 1 or len(configurations) == 0):
-            form.base_fields[
-                "from_email"
-            ].initial = configurations.first().email_host_user
-        return form
+    # March 2025: commenting out the get_form override
+    # given how active accounts worked, I don't think this worked
+    # and I think it's more dangerous to pick a random default
+
+    # def get_form(self, request, obj=None, **kwargs):
+    #     # Try to get active Outbox and prepopulate from_email field
+    #     form = super(OutgoingEmailAdmin, self).get_form(request, obj, **kwargs)
+    #     configurations = Outbox.objects.filter(active=True)
+    #     if not (len(configurations) > 1 or len(configurations) == 0):
+    #         form.base_fields[
+    #             "from_email"
+    #         ].initial = configurations.first().email_host_user
+    #     return form
 
     def save_model(self, request, obj, form, change):
         super(OutgoingEmailAdmin, self).save_model(request, obj, form, change)

--- a/django_mail_admin/admin.py
+++ b/django_mail_admin/admin.py
@@ -87,17 +87,17 @@ def get_new_mail(mailbox_admin, request, queryset):
 get_new_mail.short_description = _("Get new mail")
 
 
-# def switch_active(mailbox_admin, request, queryset):
-#     for mailbox in queryset.all():
-#         mailbox.active = not mailbox.active
-#         mailbox.save()
-#
-#
-# switch_active.short_description = _("Switch active status")
+def switch_active(mailbox_admin, request, queryset):
+    for mailbox in queryset.all():
+        mailbox.active = not mailbox.active
+        mailbox.save()
+
+
+switch_active.short_description = _("Switch active status")
 
 
 def send_queued_mail(outbox_admin, request, queryset):
-    outbox: Outbox = None
+    outbox: Outbox | None = None
     for outbox in queryset.all():
         # if not outbox.active:
         #     messages.error("Outbox not active!")
@@ -147,7 +147,7 @@ class MailboxAdmin(get_parent()):
     readonly_fields = [
         "last_polling",
     ]
-    actions = [get_new_mail]#, switch_active]
+    actions = [get_new_mail, switch_active]
 
 
 class IncomingAttachmentInline(admin.TabularInline):
@@ -489,9 +489,9 @@ class OutboxAdmin(admin.ModelAdmin):
         "email_host_user",
         "email_port",
         "id",
-        "active",
+        #"active",
     )
-    list_filter = ("active",)
+    #list_filter = ("active",)
     actions = [send_queued_mail]
 
 

--- a/django_mail_admin/backends.py
+++ b/django_mail_admin/backends.py
@@ -38,12 +38,12 @@ class CustomEmailBackend(EmailBackend):
         **kwargs,
     ):
         super(CustomEmailBackend, self).__init__(fail_silently=fail_silently)
-        # March2025 ChargeUp note: keeping active=True in case we use this to prevent false sends
-        # if we copy this we should do from user/email filtering like O365/Gmail backends
+        # March2025 Note: keeping active=True in case we use this.
+        # if we copy this we should add from user/email filtering like O365/Gmail backends
         configurations = Outbox.objects.filter(active=True)
         if len(configurations) > 1 or len(configurations) == 0:
             raise ValueError(
-                "Got %(l)s active configurations, expected 1"
+                "Got %(l)s active Outboxes, expected 1"
                 % {"l": len(configurations)}
             )
         else:
@@ -132,7 +132,7 @@ class O365Backend(EmailBackend):
     def _validate_configuration(self, configuration: Outbox) -> None:
         """Validates if we need to create a new connection based on configuration"""
         if not configuration:
-            raise ValueError("No active email configuration found")
+            raise ValueError("No Outbox found")
 
         # If configuration has changed, close existing connection
         if self.configuration_id != configuration.id:
@@ -211,7 +211,7 @@ class O365Backend(EmailBackend):
 
                     if not configuration:
                         raise ValueError(
-                            f"No active configuration found for sender: {msg.from_email}"
+                            f"No Outbox found for sender: {msg.from_email}"
                         )
 
                     # If connection doesn't match this message's configuration, create new connection

--- a/django_mail_admin/backends.py
+++ b/django_mail_admin/backends.py
@@ -323,19 +323,15 @@ class GmailOAuth2Backend(EmailBackend):
             # sort by from_email to reduce connection opening
             email_messages = sorted(email_messages, key=lambda m: m.from_email)
 
-            from_email_to_oauth_cache = {}
             for message in email_messages:
                 try:
                     # hack way to get the original username
-                    if message.from_email in from_email_to_oauth_cache:
-                        oauth_username = from_email_to_oauth_cache[message.from_email]
-                    else:
-                        oauth_username = (
-                             EmailAddressOAuthMapping.objects.filter(send_as_email=message.from_email)
-                             .values_list('oauth_username', flat=True)
-                             .first()
-                        ) or message.from_email
-                        from_email_to_oauth_cache[message.from_email] = oauth_username
+                    # TODO: could do a cache here
+                    oauth_username = (
+                         EmailAddressOAuthMapping.objects.filter(send_as_email=message.from_email)
+                         .values_list('oauth_username', flat=True)
+                         .first()
+                    ) or message.from_email
 
                     # Check if we need to reinitialize for a different from_email
                     if (not self.connection or

--- a/django_mail_admin/backends.py
+++ b/django_mail_admin/backends.py
@@ -261,11 +261,11 @@ class GmailOAuth2Backend(EmailBackend):
     def lookup_email(self) -> str | None:
         return self.from_oauth_user or self.from_email
 
-    def _initialize_connection(self, from_email: str) -> None:
+    def _initialize_connection(self, from_oauth_email: str) -> None:
         """Initialize connection settings based on from_email"""
         configuration = Outbox.objects.filter(
             email_host__icontains="gmail",
-            email_host_user=self.lookup_email
+            email_host_user=from_oauth_email or self.lookup_email
         ).first()
 
         if not configuration:
@@ -273,6 +273,7 @@ class GmailOAuth2Backend(EmailBackend):
                 f"Unable to find an Outbox with email_host__icontains=gmail email_host_user={self.lookup_email} from_oauth_user={self.from_oauth_user} from_email={self.from_email}")
 
         self.configuration_id = configuration.id
+        self.from_oauth_user = from_oauth_email
 
         # Initialize settings from configuration
         self.host = configuration.email_host or "smtp.gmail.com"

--- a/django_mail_admin/connections.py
+++ b/django_mail_admin/connections.py
@@ -24,11 +24,12 @@ class ConnectionHandler(object):
         except KeyError:
             pass
 
-        # as a hack other places are using backend_alias;;;from_oauth_user
+        # as a hack other places are using backend_alias;;;from_oauth_user. e.g. o365;;;email@example.com
         # or backend_alias???from_email
+        # previously it just used any outbox for the alias
         real_alias = maybe_hacked_alias
-        from_oauth_user = None
-        from_email = None
+        from_oauth_user: str | None = None
+        from_email: str | None = None
         if "???" in maybe_hacked_alias:
             real_alias,from_email = maybe_hacked_alias.split("???")
         elif ";;;" in maybe_hacked_alias:

--- a/django_mail_admin/connections.py
+++ b/django_mail_admin/connections.py
@@ -16,23 +16,39 @@ class ConnectionHandler(object):
     def __init__(self):
         self._connections = local()
 
-    def __getitem__(self, alias):
+    def __getitem__(self, maybe_hacked_alias):
         try:
-            return self._connections.connections[alias]
+            return self._connections.connections[maybe_hacked_alias]
         except AttributeError:
             self._connections.connections = {}
         except KeyError:
             pass
 
-        try:
-            backend = get_backend(alias)
-        except KeyError:
-            raise KeyError('%s is not a valid backend alias' % alias)
+        # as a hack other places are using backend_alias;;;from_oauth_user
+        # or backend_alias???from_email
+        real_alias = maybe_hacked_alias
+        from_oauth_user = None
+        from_email = None
+        if "???" in maybe_hacked_alias:
+            real_alias,from_email = maybe_hacked_alias.split("???")
+        elif ";;;" in maybe_hacked_alias:
+            real_alias,from_oauth_user = maybe_hacked_alias.split(";;;")
 
-        connection = get_connection(backend)
-        connection.open()
-        self._connections.connections[alias] = connection
-        return connection
+        try:
+            backend = get_backend(real_alias)
+        except KeyError:
+            raise KeyError('%s is not a valid backend alias' % real_alias)
+
+        # backend_class is a EmailBackend subclass like O365Backend or GmailOAuth2Backend
+        backend_class = get_connection(backend)
+
+        # now mutate the backend class after init since get_connection is within django
+        backend_class.from_email = from_email
+        backend_class.from_oauth_user = from_oauth_user
+
+        backend_class.open()
+        self._connections.connections[maybe_hacked_alias] = backend_class
+        return backend_class
 
     def all(self):
         return getattr(self._connections, 'connections', {}).values()

--- a/django_mail_admin/connections.py
+++ b/django_mail_admin/connections.py
@@ -29,22 +29,22 @@ class ConnectionHandler(object):
         real_alias = maybe_hacked_alias
         from_email: str | None = None
         if ";;;" in maybe_hacked_alias:
-            real_alias,from_oauth_user = maybe_hacked_alias.split(";;;")
+            real_alias,from_email = maybe_hacked_alias.split(";;;")
 
         try:
-            backend = get_backend(real_alias)
+            backend_class = get_backend(real_alias)
         except KeyError:
             raise KeyError('%s is not a valid backend alias' % real_alias)
 
-        # backend_class is a EmailBackend subclass like O365Backend or GmailOAuth2Backend
-        backend_class = get_connection(backend)
+        # backend_instance is a EmailBackend subclass like O365Backend or GmailOAuth2Backend
+        backend_instance = get_connection(backend_class)
 
         # now mutate the backend class after init since get_connection is within django
-        backend_class.from_email = from_email
+        backend_instance.from_email = from_email
 
-        backend_class.open()
-        self._connections.connections[maybe_hacked_alias] = backend_class
-        return backend_class
+        backend_instance.open()
+        self._connections.connections[maybe_hacked_alias] = backend_instance
+        return backend_instance
 
     def all(self):
         return getattr(self._connections, 'connections', {}).values()

--- a/django_mail_admin/connections.py
+++ b/django_mail_admin/connections.py
@@ -24,15 +24,11 @@ class ConnectionHandler(object):
         except KeyError:
             pass
 
-        # as a hack other places are using backend_alias;;;from_oauth_user. e.g. o365;;;email@example.com
-        # or backend_alias???from_email
+        # as a hack other places are using backend_alias;;;from_email. e.g. o365;;;email@example.com
         # previously it just used any outbox for the alias
         real_alias = maybe_hacked_alias
-        from_oauth_user: str | None = None
         from_email: str | None = None
-        if "???" in maybe_hacked_alias:
-            real_alias,from_email = maybe_hacked_alias.split("???")
-        elif ";;;" in maybe_hacked_alias:
+        if ";;;" in maybe_hacked_alias:
             real_alias,from_oauth_user = maybe_hacked_alias.split(";;;")
 
         try:
@@ -45,7 +41,6 @@ class ConnectionHandler(object):
 
         # now mutate the backend class after init since get_connection is within django
         backend_class.from_email = from_email
-        backend_class.from_oauth_user = from_oauth_user
 
         backend_class.open()
         self._connections.connections[maybe_hacked_alias] = backend_class

--- a/django_mail_admin/management/commands/get_new_mail.py
+++ b/django_mail_admin/management/commands/get_new_mail.py
@@ -10,7 +10,8 @@ logging.basicConfig(level=logging.INFO)
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        mailboxes = Mailbox.active_mailboxes.all()
+        #mailboxes = Mailbox.active_mailboxes.all()
+        mailboxes = Mailbox.objects.all()
         if args:
             mailboxes = mailboxes.filter(
                 name=' '.join(args)

--- a/django_mail_admin/management/commands/get_new_mail.py
+++ b/django_mail_admin/management/commands/get_new_mail.py
@@ -10,8 +10,7 @@ logging.basicConfig(level=logging.INFO)
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        #mailboxes = Mailbox.active_mailboxes.all()
-        mailboxes = Mailbox.objects.all()
+        mailboxes = Mailbox.active_mailboxes.all()
         if args:
             mailboxes = mailboxes.filter(
                 name=' '.join(args)

--- a/django_mail_admin/models/configurations.py
+++ b/django_mail_admin/models/configurations.py
@@ -59,19 +59,22 @@ class Outbox(models.Model):
     email_timeout = models.PositiveSmallIntegerField(
         "EMAIL_TIMEOUT", null=True, blank=True
     )
+    # deprecated field us at ChargeUp or not using anymore. keeping for compatability.
     active = models.BooleanField(_("Active"), default=False)
 
     def save(self, *args, **kwargs):
         # Only one item can be active at a time
 
-        if self.active:
-            # select all other active items
-            qs = type(self).objects.filter(active=True)
-            # except self (if self already exists)
-            if self.pk:
-                qs = qs.exclude(pk=self.pk)
-            # and deactive them
-            qs.update(active=False)
+        # ChargeUp Note: this was a previous side effect on Outbox.save
+
+        # if self.active:
+        #     # select all other active items
+        #     qs = type(self).objects.filter(active=True)
+        #     # except self (if self already exists)
+        #     if self.pk:
+        #         qs = qs.exclude(pk=self.pk)
+        #     # and deactive them
+        #     qs.update(active=False)
 
         super(Outbox, self).save(*args, **kwargs)
 

--- a/django_mail_admin/models/configurations.py
+++ b/django_mail_admin/models/configurations.py
@@ -59,13 +59,14 @@ class Outbox(models.Model):
     email_timeout = models.PositiveSmallIntegerField(
         "EMAIL_TIMEOUT", null=True, blank=True
     )
-    # deprecated field us at ChargeUp or not using anymore. keeping for compatability.
+    # deprecated field we're no longer actively using. keeping for test/code compatability.
     active = models.BooleanField(_("Active"), default=False)
 
     def save(self, *args, **kwargs):
         # Only one item can be active at a time
 
-        # ChargeUp Note: this was a previous side effect on Outbox.save
+        # March2025 Note: this was a previous side effect on Outbox.save
+        # we're not using the concept of a singleton Active Outbox
 
         # if self.active:
         #     # select all other active items

--- a/django_mail_admin/models/outgoing.py
+++ b/django_mail_admin/models/outgoing.py
@@ -14,7 +14,6 @@ from django_mail_admin.settings import get_log_level, get_backend_names_str
 from django_mail_admin.signals import email_sent, email_failed_to_send, email_queued
 from django_mail_admin.utils import get_attachment_save_path, PRIORITY, STATUS
 from django_mail_admin.validators import validate_email_with_name
-from . import Outbox
 from .templates import EmailTemplate
 
 logger = logging.getLogger(__name__)
@@ -111,7 +110,7 @@ class OutgoingEmail(models.Model):
 
         return self.prepare_email_message(outbox=outbox)
 
-    def prepare_email_message(self, outbox: Outbox | None=None):
+    def prepare_email_message(self, outbox=None):
         """
         Returns a django ``EmailMessage`` or ``EmailMultiAlternatives`` object,
         depending on whether html_message is empty.

--- a/django_mail_admin/models/outgoing.py
+++ b/django_mail_admin/models/outgoing.py
@@ -136,11 +136,12 @@ class OutgoingEmail(models.Model):
         if outbox:
             hack_alias = self.backend_alias + ";;;" + outbox.email_host_user
         else:
-            # we effectively always want an outbox passed in but keeping for compatability
+            # we effectively always want an outbox passed in but keeping this for compatability
             # lets fallback to the message from_email in this case (this might cause more Outbox lookup failures)
-            hack_alias = self.backend_alias + "???" + self.from_email
+            hack_alias = self.backend_alias + ";;;" + self.from_email
 
         # this will open and cache a connection to the alias above
+        # maybe remove this and only open a connection on send
         connection = connections[hack_alias]
 
         if html_message:

--- a/django_mail_admin/models/outgoing.py
+++ b/django_mail_admin/models/outgoing.py
@@ -101,16 +101,16 @@ class OutgoingEmail(models.Model):
 
         return Context(context)
 
-    def email_message(self):
+    def email_message(self, outbox=None):
         """
         Returns Django EmailMessage object for sending.
         """
         if self._cached_email_message:
             return self._cached_email_message
 
-        return self.prepare_email_message()
+        return self.prepare_email_message(outbox=outbox)
 
-    def prepare_email_message(self):
+    def prepare_email_message(self, outbox=None):
         """
         Returns a django ``EmailMessage`` or ``EmailMultiAlternatives`` object,
         depending on whether html_message is empty.
@@ -124,7 +124,23 @@ class OutgoingEmail(models.Model):
             subject = self.subject
             html_message = self.html_message
 
-        connection = connections[self.backend_alias or "default"]
+        # hack: OG version commented out below
+        #connection = connections[self.backend_alias or "default"]
+
+        # this adds a connection for the outbox we're intending to send from rather than something like:
+        # "any 0365 outbox" or "any active outbox"
+        # we should also likely always have a backend alias
+        if not self.backend_alias:
+            raise ValueError(f"Outgoing emails should always have a backend alias. It was: {self.backend_alias} for from_email: {self.from_email}")
+
+        if outbox:
+            hack_alias = self.backend_alias + ";;;" + outbox.email_host_user
+        else:
+            # we effectively always want an outbox passed in but keeping for compatability
+            # let's fallback to the from email in this case, which might cause more misses
+            hack_alias = self.backend_alias + "???" + self.from_email
+
+        connection = connections[hack_alias]
 
         if html_message:
             msg = EmailMultiAlternatives(
@@ -181,14 +197,16 @@ class OutgoingEmail(models.Model):
             retval = True
         return retval
 
-    def dispatch(self, log_level=None, commit=True):
+    def dispatch(self, outbox=None, log_level=None, commit=True):
         """
         Sends email and log the result.
+
+        outbox: Attach an outbox to ensure the right outbox is used for connections/validation.
         """
         email_message = None
         # Priority is handled in mail.send
         try:
-            email_message = self.email_message()
+            email_message = self.email_message(outbox=outbox)
             email_message.send()
             status = STATUS.sent
             self._update_message_id()
@@ -351,7 +369,7 @@ class EmailAddressOAuthMapping(models.Model):
     )
 
     class Meta:
-        app_label = 'django_mail_admin' 
+        app_label = 'django_mail_admin'
         verbose_name = _("Email OAuth Mapping")
         verbose_name_plural = _("Email OAuth Mappings")
 


### PR DESCRIPTION
Choose the associated Outbox based on an explicit email address passed in.

Also, remove a bunch of active=True checks. We haven't been regularly using it and it just complicates things.

## Testing

O365 worked locally. Gmail was tougher to test due to lack of social auth locally and not wanting to OAuth locally.